### PR TITLE
Add option to scale images. Closes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const termImg = require('term-img');
 const PIXEL = '\u2584';
 const readFile = util.promisify(fs.readFile);
 
-function asPercent (value) {
+function asPercent(value) {
 	return `${Math.round(value * 100)}%`;
 }
 

--- a/index.js
+++ b/index.js
@@ -8,13 +8,17 @@ const termImg = require('term-img');
 const PIXEL = '\u2584';
 const readFile = util.promisify(fs.readFile);
 
-async function render(buffer) {
+function asPercent (value) {
+	return `${Math.round(value * 100)}%`;
+}
+
+async function render(buffer, factor) {
 	const image = await Jimp.read(buffer);
 	const columns = process.stdout.columns || 80;
 	const rows = process.stdout.rows || 24;
 
 	if (image.bitmap.width > columns || (image.bitmap.height / 2) > rows) {
-		image.scaleToFit(columns, rows * 2);
+		image.scaleToFit(columns * factor, rows * 2 * factor);
 	}
 
 	let ret = '';
@@ -36,12 +40,12 @@ async function render(buffer) {
 	return ret;
 }
 
-exports.buffer = async buffer => {
+exports.buffer = async (buffer, factor = 1) => {
 	return termImg.string(buffer, {
-		width: '100%',
-		height: '100%',
-		fallback: () => render(buffer)
+		width: asPercent(factor),
+		height: asPercent(factor),
+		fallback: () => render(buffer, factor)
 	});
 };
 
-exports.file = async filePath => exports.buffer(await readFile(filePath));
+exports.file = async (filePath, factor) => exports.buffer(await readFile(filePath), factor);

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,22 @@ const terminalImage = require('terminal-image');
 })();
 ```
 
+Optionally, you can specify a `factor` to scale the image:
+
+```js
+const terminalImage = require('terminal-image');
+
+(async () => {
+	console.log(await terminalImage.file('unicorn.jpg', 0.5));
+})();
+```
+
 
 ## API
 
 Supports PNG and JPEG images.
 
-### terminalImage.buffer(imageBuffer)
+### terminalImage.buffer(imageBuffer, [factor])
 
 Returns a `Promise<string>` with the ansi escape codes to display the image.
 
@@ -41,7 +51,7 @@ Type: `Buffer`
 
 Buffer with the image.
 
-### terminalImage.file(filePath)
+### terminalImage.file(filePath, [factor])
 
 Returns a `Promise<string>` with the ansi escape codes to display the image.
 


### PR DESCRIPTION
Hi @sindresorhus 😊 

I have created a PR to scale images, as requested in #1.

Since I wanted to keep the aspect-ratio, I only introduced a single `factor` parameter, not separate options for `width` and `height`.

I hope you like the changes 😊 