### PR TITLE
Add `width` and `height` option

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,6 +1,8 @@
+#!/usr/bin/env node
+
 'use strict';
 const terminalImage = require('.');
 
 (async () => {
-	console.log(await terminalImage.file('fixture.jpg'));
+	console.log(await terminalImage('fixture.jpg'));
 })();

--- a/index.js
+++ b/index.js
@@ -23,9 +23,9 @@ async function render(fileBuffer, {factor}) {
 	for (let y = 0; y < image.bitmap.height - 1; y += 2) {
 		for (let x = 0; x < image.bitmap.width; x++) {
 			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
-			const {r: r2, g: g2, b: b2} = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
+			const {r: r2, g: g2, b: b2, a: a2} = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
 
-			if (a === 0) {
+			if (a === 0 && a2 === 0) {
 				ret += chalk.reset(' ');
 			} else {
 				ret += chalk.bgRgb(r, g, b).rgb(r2, g2, b2)(PIXEL);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const termImg = require('term-img');
 const PIXEL = '\u2584';
 const readFile = util.promisify(fs.readFile);
 
-function asPercent (value) {
+function asPercent(value) {
 	return `${Math.round(value * 100)}%`;
 }
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ async function render(fileBuffer, {height, width}) {
 	// Each character has two vertical blocks, so we double the number of rows
 	height *= 2;
 
+	height = Math.round(height);
+	width = Math.round(width);
+
 	if (height !== bitmap.height || width !== bitmap.width) {
 		image.resize(width, height);
 	}
@@ -52,7 +55,8 @@ async function render(fileBuffer, {height, width}) {
 	}
 
 	// Image has an odd number of rows
-	if (y === bitmap.height - 1) {
+	if (height % 2) {
+		const y = height - 1;
 		for (let x = 0; x < bitmap.width; x++) {
 			const {r, g, b} = Jimp.intToRGBA(image.getPixelColor(x, y));
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,50 @@ const terminalCharWidth = require('terminal-char-width');
 const CHAR_HEIGHT = 16;
 const CHAR_WIDTH = CHAR_HEIGHT * terminalCharWidth;
 
+/**
+ * Check if two colors are equal
+ *
+ * Both has `alpha=0`, or `alpha>0` and equl all the other color values
+ *
+ * @returns {Boolean} colors are equal
+ */
+function equalColor({r, g, b, a}, {r: r2, g: g2, b: b2, a: a2}) {
+	if (a === 0 && a2 === 0) {
+		return true;
+	}
+
+	return a > 0 && a2 > 0 && r === r2 && g === g2 && b === b2;
+}
+
+function getBgColor({r, g, b, a}) {
+	// Full transparent
+	if (a === 0) {
+		return chalk.reset;
+	}
+
+	return chalk.bgRgb(r, g, b);
+}
+
+function getFgColor({r, g, b}) {
+	return chalk.rgb(r, g, b);
+}
+
+function getGlyph(upper, lower) {
+	if (upper.a) {
+		if (lower && equalColor(upper, lower)) {
+			return '█';
+		}
+
+		return '▀';
+	}
+
+	if (lower && lower.a) {
+		return '▄';
+	}
+
+	return ' ';
+}
+
 async function render(fileBuffer, {height, width}) {
 	const image = await Jimp.read(fileBuffer);
 	const {bitmap} = image;
@@ -33,45 +77,65 @@ async function render(fileBuffer, {height, width}) {
 
 	const ret = new Array(Math.ceil(bitmap.height / 2));
 	for (let y = 0; y < bitmap.height - 1; y += 2) {
-		const rowIndex = y / 2;
 		let row = '';
-		for (let x = 0; x < bitmap.width; x++) {
-			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
-			const {r: r2, g: g2, b: b2, a: a2} = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
+		let prevFgColor = Jimp.intToRGBA(image.getPixelColor(0, y));
+		let prevBgColor = Jimp.intToRGBA(image.getPixelColor(0, y + 1));
+		let buffer = getGlyph(prevFgColor, prevBgColor);
 
-			if (a === 0 && a2 === 0) {
-				// Both pixels are full transparent
-				row += chalk.reset(' ');
-			} else if (a) {
-				// Only upper pixel is full transparent
-				row += chalk.rgb(r2, g2, b2)('▄');
-			} else if (a2) {
-				// Only lower pixel is full transparent
-				row += chalk.rgb(r, g, b)('▀');
-			} else if (r === r2 && g === g2 && b === b2) {
-				// Both pixels has the same color
-				row += chalk.rgb(r, g, b)('█');
-			} else {
-				// Pixels has different colors
-				row += chalk.rgb(r, g, b).bgRgb(r2, g2, b2)('▀');
+		for (let x = 1; x < bitmap.width; x++) {
+			let fgColor = Jimp.intToRGBA(image.getPixelColor(x, y));
+			let bgColor = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
+			const glyph = getGlyph(fgColor, bgColor);
+
+			// Special case where upper pixel is full transparent but lower one not,
+			// set foreground color to the lower pixel one and set background as
+			// transparent since we are drawing a lower half block
+			if (fgColor.a === 0 && bgColor.a > 0) {
+				fgColor = bgColor;
+				bgColor = {a: 0};
 			}
+
+			// TODO optimization: check foreground and background independently and
+			// also the case of upper block full transparent
+			if (equalColor(prevFgColor, fgColor) && equalColor(prevBgColor, bgColor)) {
+				buffer += glyph;
+				continue;
+			}
+
+			row += getBgColor(prevBgColor)(getFgColor(prevFgColor)(buffer));
+
+			prevFgColor = fgColor;
+			prevBgColor = bgColor;
+			buffer = glyph;
 		}
 
-		ret[rowIndex] = row;
+		ret[y / 2] = row + getBgColor(prevBgColor)(getFgColor(prevFgColor)(buffer));
 	}
 
 	// Image has an odd number of rows
 	if (height % 2) {
 		const y = height - 1;
-		const rowIndex = y / 2;
-		let row = '';
-		for (let x = 0; x < bitmap.width; x++) {
-			const {r, g, b} = Jimp.intToRGBA(image.getPixelColor(x, y));
 
-			row += chalk.rgb(r, g, b)('▀');
+		let row = '';
+		let prevFgColor = Jimp.intToRGBA(image.getPixelColor(0, y));
+		let buffer = getGlyph(prevFgColor);
+
+		for (let x = 1; x < bitmap.width; x++) {
+			const fgColor = Jimp.intToRGBA(image.getPixelColor(x, y));
+			const glyph = getGlyph(fgColor);
+
+			if (equalColor(prevFgColor, fgColor)) {
+				buffer += glyph;
+				continue;
+			}
+
+			row += getFgColor(prevFgColor)(buffer);
+
+			prevFgColor = fgColor;
+			buffer = glyph;
 		}
 
-		ret[rowIndex] = row;
+		ret[y / 2] = row + getFgColor(prevFgColor)(buffer);
 	}
 
 	return ret.join('\n');

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
-const chalk = require('chalk');
+
 const Jimp = require('@sindresorhus/jimp');
-const termImg = require('term-img');
+const chalk = require('chalk');
+const {string: termImg} = require('term-img');
 
 const PIXEL = '\u2584';
 
@@ -38,7 +39,7 @@ async function render(fileBuffer, factor) {
 }
 
 module.exports = (fileBuffer, factor = 1) => {
-	return termImg.string(fileBuffer, {
+	return termImg(fileBuffer, {
 		width: asPercent(factor),
 		height: asPercent(factor),
 		fallback: () => render(fileBuffer, factor)

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function asPercent(value) {
 	return `${Math.round(value * 100)}%`;
 }
 
-async function render(fileBuffer, factor) {
+async function render(fileBuffer, {factor}) {
 	const image = await Jimp.read(fileBuffer);
 	const columns = process.stdout.columns || 80;
 	const rows = process.stdout.rows || 24;
@@ -38,10 +38,10 @@ async function render(fileBuffer, factor) {
 	return ret;
 }
 
-module.exports = (fileBuffer, factor = 1) => {
+module.exports = (fileBuffer, {factor=1}={}) => {
 	return termImg(fileBuffer, {
 		width: asPercent(factor),
 		height: asPercent(factor),
-		fallback: () => render(fileBuffer, factor)
+		fallback: () => render(fileBuffer, {factor})
 	});
 };

--- a/index.js
+++ b/index.js
@@ -18,8 +18,9 @@ async function render(fileBuffer, {factor}) {
 	}
 
 	let ret = '';
-	for (let y = 0; y < image.bitmap.height - 1; y += 2) {
-		for (let x = 0; x < image.bitmap.width; x++) {
+	let y = 0;
+	while (y < bitmap.height - 1) {
+		for (let x = 0; x < bitmap.width; x++) {
 			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
 			const {r: r2, g: g2, b: b2, a: a2} = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
 
@@ -33,10 +34,20 @@ async function render(fileBuffer, {factor}) {
 
 			// Pixels has different colors
 			else
-				ret += chalk.bgRgb(r, g, b).rgb(r2, g2, b2)('▄');
+				ret += chalk.rgb(r, g, b).bgRgb(r2, g2, b2)('▀');
 		}
 
 		ret += '\n';
+		y += 2;
+	}
+
+	// Image has an odd number of rows
+	if (y === bitmap.height - 1) {
+		for (let x = 0; x < bitmap.width; x++) {
+			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
+
+			ret += chalk.rgb(r, g, b)('▀');
+		}
 	}
 
 	return ret;

--- a/index.js
+++ b/index.js
@@ -32,8 +32,7 @@ async function render(fileBuffer, {height, width}) {
 	}
 
 	let ret = '';
-	let y = 0;
-	while (y < bitmap.height - 1) {
+	for (let y = 0; y < bitmap.height - 1; y += 2) {
 		for (let x = 0; x < bitmap.width; x++) {
 			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
 			const {r: r2, g: g2, b: b2, a: a2} = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
@@ -51,7 +50,6 @@ async function render(fileBuffer, {height, width}) {
 		}
 
 		ret += '\n';
-		y += 2;
 	}
 
 	// Image has an odd number of rows

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function getGlyph(upper, lower) {
 	return ' ';
 }
 
-async function render(fileBuffer, {height, width}) {
+async function render(fileBuffer, {asArray, height, width}) {
 	const image = await Jimp.read(fileBuffer);
 	const {bitmap} = image;
 
@@ -151,12 +151,12 @@ async function render(fileBuffer, {height, width}) {
 		ret[y / 2] = row + getFgColor(prevFgColor)(buffer);
 	}
 
-	return ret.join('\n');
+	return asArray ? ret : ret.join('\n');
 }
 
-module.exports = function (fileBuffer, {height, width} = {}) {
+module.exports = function (fileBuffer, {asArray, height, width} = {}) {
 	function fallback() {
-		return render(fileBuffer, {height, width});
+		return render(fileBuffer, {asArray, height, width});
 	}
 
 	return termImg(fileBuffer, {fallback, height, width});

--- a/index.js
+++ b/index.js
@@ -24,17 +24,16 @@ async function render(fileBuffer, {factor}) {
 			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
 			const {r: r2, g: g2, b: b2, a: a2} = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
 
-			// Both pixels are full transparent
-			if (a === 0 && a2 === 0)
+			if (a === 0 && a2 === 0) {
+				// Both pixels are full transparent
 				ret += chalk.reset(' ');
-
-			// Both pixels has the same color
-			else if (r === r2 && g === g2 && b === b2)
+			} else if (r === r2 && g === g2 && b === b2) {
+				// Both pixels has the same color
 				ret += chalk.rgb(r, g, b)('█');
-
-			// Pixels has different colors
-			else
+			} else {
+				// Pixels has different colors
 				ret += chalk.rgb(r, g, b).bgRgb(r2, g2, b2)('▀');
+			}
 		}
 
 		ret += '\n';
@@ -44,7 +43,7 @@ async function render(fileBuffer, {factor}) {
 	// Image has an odd number of rows
 	if (y === bitmap.height - 1) {
 		for (let x = 0; x < bitmap.width; x++) {
-			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
+			const {r, g, b} = Jimp.intToRGBA(image.getPixelColor(x, y));
 
 			ret += chalk.rgb(r, g, b)('▀');
 		}

--- a/index.js
+++ b/index.js
@@ -42,6 +42,12 @@ async function render(fileBuffer, {height, width}) {
 			if (a === 0 && a2 === 0) {
 				// Both pixels are full transparent
 				row += chalk.reset(' ');
+			} else if (a) {
+				// Only upper pixel is full transparent
+				row += chalk.rgb(r2, g2, b2)('▄');
+			} else if (a2) {
+				// Only lower pixel is full transparent
+				row += chalk.rgb(r, g, b)('▀');
 			} else if (r === r2 && g === g2 && b === b2) {
 				// Both pixels has the same color
 				row += chalk.rgb(r, g, b)('█');

--- a/index.js
+++ b/index.js
@@ -1,19 +1,16 @@
 'use strict';
-const util = require('util');
-const fs = require('fs');
 const chalk = require('chalk');
 const Jimp = require('@sindresorhus/jimp');
 const termImg = require('term-img');
 
 const PIXEL = '\u2584';
-const readFile = util.promisify(fs.readFile);
 
 function asPercent(value) {
 	return `${Math.round(value * 100)}%`;
 }
 
-async function render(buffer, factor) {
-	const image = await Jimp.read(buffer);
+async function render(fileBuffer, factor) {
+	const image = await Jimp.read(fileBuffer);
 	const columns = process.stdout.columns || 80;
 	const rows = process.stdout.rows || 24;
 
@@ -40,12 +37,10 @@ async function render(buffer, factor) {
 	return ret;
 }
 
-exports.buffer = async (buffer, factor = 1) => {
-	return termImg.string(buffer, {
+module.exports = (fileBuffer, factor = 1) => {
+	return termImg.string(fileBuffer, {
 		width: asPercent(factor),
 		height: asPercent(factor),
-		fallback: () => render(buffer, factor)
+		fallback: () => render(fileBuffer, factor)
 	});
 };
-
-exports.file = async (filePath, factor) => exports.buffer(await readFile(filePath), factor);

--- a/index.js
+++ b/index.js
@@ -23,11 +23,17 @@ async function render(fileBuffer, {factor}) {
 			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
 			const {r: r2, g: g2, b: b2, a: a2} = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
 
-			if (a === 0 && a2 === 0) {
+			// Both pixels are full transparent
+			if (a === 0 && a2 === 0)
 				ret += chalk.reset(' ');
-			} else {
+
+			// Both pixels has the same color
+			else if (r === r2 && g === g2 && b === b2)
+				ret += chalk.rgb(r, g, b)('█');
+
+			// Pixels has different colors
+			else
 				ret += chalk.bgRgb(r, g, b).rgb(r2, g2, b2)('▄');
-			}
 		}
 
 		ret += '\n';

--- a/index.js
+++ b/index.js
@@ -31,38 +31,44 @@ async function render(fileBuffer, {height, width}) {
 		image.resize(width, height);
 	}
 
-	let ret = '';
+	const ret = new Array(Math.ceil(bitmap.height / 2));
 	for (let y = 0; y < bitmap.height - 1; y += 2) {
+		const rowIndex = y / 2;
+		let row = '';
 		for (let x = 0; x < bitmap.width; x++) {
 			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
 			const {r: r2, g: g2, b: b2, a: a2} = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
 
 			if (a === 0 && a2 === 0) {
 				// Both pixels are full transparent
-				ret += chalk.reset(' ');
+				row += chalk.reset(' ');
 			} else if (r === r2 && g === g2 && b === b2) {
 				// Both pixels has the same color
-				ret += chalk.rgb(r, g, b)('█');
+				row += chalk.rgb(r, g, b)('█');
 			} else {
 				// Pixels has different colors
-				ret += chalk.rgb(r, g, b).bgRgb(r2, g2, b2)('▀');
+				row += chalk.rgb(r, g, b).bgRgb(r2, g2, b2)('▀');
 			}
 		}
 
-		ret += '\n';
+		ret[rowIndex] = row;
 	}
 
 	// Image has an odd number of rows
 	if (height % 2) {
 		const y = height - 1;
+		const rowIndex = y / 2;
+		let row = '';
 		for (let x = 0; x < bitmap.width; x++) {
 			const {r, g, b} = Jimp.intToRGBA(image.getPixelColor(x, y));
 
-			ret += chalk.rgb(r, g, b)('▀');
+			row += chalk.rgb(r, g, b)('▀');
 		}
+
+		ret[rowIndex] = row;
 	}
 
-	return ret;
+	return ret.join('\n');
 }
 
 module.exports = function (fileBuffer, {height, width} = {}) {

--- a/index.js
+++ b/index.js
@@ -87,16 +87,29 @@ async function render(fileBuffer, {height, width}) {
 			let bgColor = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
 			const glyph = getGlyph(fgColor, bgColor);
 
-			// Special case where upper pixel is full transparent but lower one not,
-			// set foreground color to the lower pixel one and set background as
-			// transparent since we are drawing a lower half block
-			if (fgColor.a === 0 && bgColor.a > 0) {
-				fgColor = bgColor;
-				bgColor = {a: 0};
+			// Optimize colors changes based on their calculated glyph
+			switch (glyph) {
+				// Both upper and lower blocks are full transparent, ignore foreground
+				case ' ':
+					fgColor = prevFgColor;
+					break;
+
+				// Special case where upper pixel is full transparent but lower one not,
+				// set foreground color to the lower pixel one and set background as
+				// transparent since we are drawing a lower half block
+				case '▄':
+					fgColor = bgColor;
+					bgColor = {a: 0};
+					break;
+
+				// Both upper and lower blocks has equal color, ignore background
+				case '█':
+					bgColor = prevBgColor;
+					break;
+
+				default:
 			}
 
-			// TODO optimization: check foreground and background independently and
-			// also the case of upper block full transparent
 			if (equalColor(prevFgColor, fgColor) && equalColor(prevBgColor, bgColor)) {
 				buffer += glyph;
 				continue;

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ async function render(fileBuffer, {asArray, height, width}) {
 		width = bitmap.width / CHAR_WIDTH;
 	} else if (height === undefined) {
 		height = bitmap.height * terminalCharWidth * width / bitmap.width;
-	} else {
+	} else if (width === undefined) {
 		width = bitmap.width / terminalCharWidth * height / bitmap.height;
 	}
 

--- a/index.js
+++ b/index.js
@@ -8,13 +8,17 @@ const termImg = require('term-img');
 const PIXEL = '\u2584';
 const readFile = util.promisify(fs.readFile);
 
-async function render(buffer) {
+function asPercent (value) {
+	return `${Math.round(value * 100)}%`;
+}
+
+async function render(buffer, factor) {
 	const image = await Jimp.read(buffer);
 	const columns = process.stdout.columns || 80;
 	const rows = process.stdout.rows || 24;
 
 	if (image.bitmap.width > columns || (image.bitmap.height / 2) > rows) {
-		image.scaleToFit(columns, rows * 2);
+		image.scaleToFit(columns * factor, rows * 2 * factor);
 	}
 
 	let ret = '';
@@ -36,12 +40,12 @@ async function render(buffer) {
 	return ret;
 }
 
-exports.buffer = async buffer => {
+exports.buffer = async (buffer, factor = 1) => {
 	return termImg.string(buffer, {
-		width: '100%',
-		height: '100%',
-		fallback: () => render(buffer)
+		width: asPercent(factor),
+		height: asPercent(factor),
+		fallback: () => render(buffer, factor)
 	});
 };
 
-exports.file = async filePath => exports.buffer(await readFile(filePath));
+exports.file = async (filePath, factor) => exports.buffer(await readFile(filePath), factor);

--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@ const Jimp = require('@sindresorhus/jimp');
 const chalk = require('chalk');
 const {string: termImg} = require('term-img');
 
-const PIXEL = '\u2584';
-
 function asPercent(value) {
 	return `${Math.round(value * 100)}%`;
 }
@@ -28,7 +26,7 @@ async function render(fileBuffer, {factor}) {
 			if (a === 0 && a2 === 0) {
 				ret += chalk.reset(' ');
 			} else {
-				ret += chalk.bgRgb(r, g, b).rgb(r2, g2, b2)(PIXEL);
+				ret += chalk.bgRgb(r, g, b).rgb(r2, g2, b2)('▄');
 			}
 		}
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 	"dependencies": {
 		"@sindresorhus/jimp": "^0.3.0",
 		"chalk": "^2.4.1",
-		"term-img": "^2.1.0"
+		"term-img": "^2.1.0",
+		"terminal-char-width": "^1.0.8"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,14 @@ Works in any terminal that supports colors.
 
 <img src="screenshot.png" width="1082">
 
-*In iTerm, the image will be [displayed in full resolution](screenshot-iterm.jpg), since iTerm has [special image support](https://www.iterm2.com/documentation-images.html).*
+*In iTerm, the image will be [displayed in full resolution](screenshot-iterm.jpg),
+since iTerm has [special image support](https://www.iterm2.com/documentation-images.html).*
 
 
 ## Install
 
-```
-$ npm install terminal-image
+```sh
+npm install terminal-image
 ```
 
 
@@ -22,17 +23,18 @@ $ npm install terminal-image
 const terminalImage = require('terminal-image');
 
 (async () => {
-	console.log(await terminalImage.file('unicorn.jpg'));
+	console.log(await terminalImage('unicorn.jpg'));
 })();
 ```
 
-Optionally, you can specify a `factor` to scale the image:
+Optionally, you can specify the `heigh` and/or `width` to scale the image. To
+maintain aspect ratio, define only one of them.
 
 ```js
 const terminalImage = require('terminal-image');
 
 (async () => {
-	console.log(await terminalImage.file('unicorn.jpg', 0.5));
+	console.log(await terminalImage('unicorn.jpg', {width: 1024}));
 })();
 ```
 
@@ -41,31 +43,23 @@ const terminalImage = require('terminal-image');
 
 Supports PNG and JPEG images.
 
-### terminalImage.buffer(imageBuffer, [factor])
+### terminalImage(fileBuffer, [options])
 
 Returns a `Promise<string>` with the ansi escape codes to display the image.
 
-#### imageBuffer
+#### fileBuffer
 
-Type: `Buffer`
+Type: `Buffer`|`string`
 
-Buffer with the image.
-
-### terminalImage.file(filePath, [factor])
-
-Returns a `Promise<string>` with the ansi escape codes to display the image.
-
-#### filePath
-
-Type: `string`
-
-File path to the image.
+Buffer with the image, or path to the image file.
 
 
 ## Related
 
-- [terminal-image-cli](https://github.com/sindresorhus/terminal-image-cli) - CLI for this module
-- [terminal-link](https://github.com/sindresorhus/terminal-link) - Create clickable links in the terminal
+- [terminal-image-cli](https://github.com/sindresorhus/terminal-image-cli) - CLI
+	for this module
+- [terminal-link](https://github.com/sindresorhus/terminal-link) - Create
+	clickable links in the terminal
 - [chalk](https://github.com/chalk/chalk) - Style and color text in the terminal
 
 

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,22 @@ const terminalImage = require('terminal-image');
 })();
 ```
 
+Optionally, you can specify a `factor` to scale the image:
+
+```js
+const terminalImage = require('terminal-image');
+
+(async () => {
+	console.log(await terminalImage.file('unicorn.jpg', 0.5));
+})();
+```
+
 
 ## API
 
 Supports PNG and JPEG images.
 
-### terminalImage.buffer(imageBuffer)
+### terminalImage.buffer(imageBuffer, [factor])
 
 Returns a `Promise<string>` with the ansi escape codes to display the image.
 
@@ -41,7 +51,7 @@ Type: `Buffer`
 
 Buffer with the image.
 
-### terminalImage.file(filePath)
+### terminalImage.file(filePath, [factor])
 
 Returns a `Promise<string>` with the ansi escape codes to display the image.
 

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ const terminalImage = require('terminal-image');
 })();
 ```
 
-Optionally, you can specify the `heigh` and/or `width` to scale the image. To
+Optionally, you can specify the `height` and/or `width` to scale the image. To
 maintain aspect ratio, define only one of them.
 
 ```js

--- a/test.js
+++ b/test.js
@@ -5,9 +5,11 @@ import terminalImage from '.';
 test('.buffer()', async t => {
 	const result = await terminalImage(fs.readFileSync('fixture.jpg'));
 	t.is(typeof result, 'string');
+	t.is(result.length, 339459);
 });
 
 test('.file()', async t => {
 	const result = await terminalImage('fixture.jpg');
 	t.is(typeof result, 'string');
+	t.is(result.length, 339459);
 });

--- a/test.js
+++ b/test.js
@@ -3,11 +3,11 @@ import test from 'ava';
 import terminalImage from '.';
 
 test('.buffer()', async t => {
-	const result = await terminalImage.buffer(fs.readFileSync('fixture.jpg'));
+	const result = await terminalImage(fs.readFileSync('fixture.jpg'));
 	t.is(typeof result, 'string');
 });
 
 test('.file()', async t => {
-	const result = await terminalImage.file('fixture.jpg');
+	const result = await terminalImage('fixture.jpg');
 	t.is(typeof result, 'string');
 });


### PR DESCRIPTION
This pull-request add support for optional `width` and `height` options, auto-adjusting size if any (or both) of them is not defined, also when running in Windows. It also unify the `file` and `buffer` functions, and fix two bugs related to alpha channel and when resized image has an odd number of rows.