### PR TITLE
Add new method that accepts raw pixel image data

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,32 +8,43 @@ const termImg = require('term-img');
 const PIXEL = '\u2584';
 const readFile = util.promisify(fs.readFile);
 
-async function render(buffer) {
-	const image = await Jimp.read(buffer);
+function scaleImage(image) {
 	const columns = process.stdout.columns || 80;
 	const rows = process.stdout.rows || 24;
-
 	if (image.bitmap.width > columns || (image.bitmap.height / 2) > rows) {
 		image.scaleToFit(columns, rows * 2);
 	}
+	return image;
+}
 
+function renderImage(image) {
 	let ret = '';
 	for (let y = 0; y < image.bitmap.height - 1; y += 2) {
 		for (let x = 0; x < image.bitmap.width; x++) {
 			const {r, g, b, a} = Jimp.intToRGBA(image.getPixelColor(x, y));
 			const {r: r2, g: g2, b: b2} = Jimp.intToRGBA(image.getPixelColor(x, y + 1));
-
 			if (a === 0) {
 				ret += chalk.reset(' ');
 			} else {
 				ret += chalk.bgRgb(r, g, b).rgb(r2, g2, b2)(PIXEL);
 			}
 		}
-
 		ret += '\n';
 	}
-
 	return ret;
+}
+
+function imageDataToImage(imageData) {
+	const image = new Jimp(imageData.width, imageData.height);
+	image.bitmap.width = imageData.width;
+	image.bitmap.height = imageData.height;
+	image.bitmap.data = Buffer.from(new Uint8ClampedArray(imageData.data));
+	return image;
+}
+
+async function render(buffer) {
+	const image = scaleImage(await Jimp.read(buffer));
+	return renderImage(image);
 }
 
 exports.buffer = async buffer => {
@@ -45,3 +56,7 @@ exports.buffer = async buffer => {
 };
 
 exports.file = async filePath => exports.buffer(await readFile(filePath));
+
+exports.imageData = imageData => {
+	return renderImage(scaleImage(imageDataToImage(imageData)));
+};

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,15 @@ Type: `string`
 
 File path to the image.
 
+### terminalImage.imageData(imageData)
+
+Returns a `string` with the ansi escape codes to display the image.
+
+#### imageData
+
+Type: `{ height: number, width: number, data: Uint8ClampedArray }`
+
+[ImageData](https://developer.mozilla.org/en-US/docs/Web/API/ImageData)-like object representing raw rgba pixels and image dimensions.
 
 ## Tip
 

--- a/test.js
+++ b/test.js
@@ -11,3 +11,23 @@ test('.file()', async t => {
 	const result = await terminalImage.file('fixture.jpg');
 	t.is(typeof result, 'string');
 });
+
+test('.imageData()', t => {
+	const height = 4;
+	const width = 4;
+	const black = [0, 0, 0, 255];
+	const white = [255, 255, 255, 255];
+	const pink = [255, 0, 255, 255];
+	const data = new Uint8ClampedArray([
+		...black, ...white, ...black, ...pink,
+		...black, ...white, ...black, ...pink,
+		...black, ...white, ...black, ...pink,
+		...black, ...white, ...black, ...pink
+	]);
+	const result = terminalImage.imageData({
+		width,
+		height,
+		data
+	});
+	t.is(typeof result, 'string');
+});


### PR DESCRIPTION
**Description**
This PR adds a new method for converting "ImageData" as described in #4 

**Changes**
- Refactored `render()` function body into 2 smaller functions: `scaleImage` and `renderImage`
- Added new `imageDataToImage()` function for converting ImageData to a `Jimp` instance
- Added new export `imageData()`
- Updated README with `imageData()` method docs

**Testing**
I created a new test case to cover the update, however, I think I could use some help identifying whether or not this method works as expected.

**Additional Info**
Although the passed imageData provides RGBA pixel data, right now, this implementation will ignore the alpha channel. I want to get a few eyes on this before I dive in further into any specific issue.

Anyways, let me know what to change/fix @sindresorhus  👍

---

Fixes #4