### PR TITLE
Improved iTerm Table Rendering

### DIFF
--- a/example-table.js
+++ b/example-table.js
@@ -1,0 +1,6 @@
+import terminalImage from './index.js';
+import Table from 'cli-table3';
+
+const table = new Table({head: ['Image', 'Description']});
+table.push([await terminalImage.file('fixture.jpg', {width: '100%', isTable: true}), 'Cute Dog'])
+console.log(table.toString());

--- a/index.js
+++ b/index.js
@@ -210,7 +210,13 @@ async function renderKitty(buffer, {width: inputWidth, height: inputHeight, pres
 
 const terminalImage = {};
 
-terminalImage.buffer = async (buffer, {width = '100%', height = '100%', preserveAspectRatio = true, isGifFrame = false} = {}) => {
+terminalImage.buffer = async (buffer, {width = '100%', height = '100%', preserveAspectRatio = true, isGifFrame = false, isTable = false} = {}) => {
+	// Return immediately as ANSI when rendering with something like 'cli-table'
+	// This should fix any issues when rendering a table and image simultaneously
+	if (isTable) {
+		return render(buffer, {height, width, preserveAspectRatio});
+	}
+
 	// Check for Kitty protocol support only if we're in an interactive terminal
 	// and not in iTerm2 (which has its own protocol)
 	// Note: We disable Kitty protocol for GIF frames as it doesn't work well with log-update


### PR DESCRIPTION
This small patch allows for images to be rendered in tables within iTerm without hindering functionality.

Fixes https://github.com/sindresorhus/terminal-image/issues/32

<img width="60%" height="100%" alt="iTerm rendering showcasing an image within a table" src="https://github.com/user-attachments/assets/767b2400-4d60-490b-ba0d-7c30193d320c" />