### PR TITLE
Ghostty compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,10 +77,12 @@ function supportsTerminalGraphics() {
 		return false;
 	}
 
-	const env = process.env;
+	const {env} = process;
 
 	// Strong indicators for Kitty
-	if (env.KITTY_WINDOW_ID) return true;
+	if (env.KITTY_WINDOW_ID) {
+		return true;
+	}
 
 	// Check TERM_PROGRAM for known graphics-capable terminals
 	const termProgram = env.TERM_PROGRAM || '';
@@ -250,16 +252,16 @@ terminalImage.buffer = async (buffer, {width = '100%', height = '100%', preserve
 		return render(buffer, {height, width, preserveAspectRatio});
 	}
 
-  // Check for terminal graphics support
-  // Note: We disable graphics protocols for GIF frames as they don't work well with log-update
-  if (!isGifFrame && supportsTerminalGraphics()) {
-    // Use terminal graphics protocol for high-quality rendering
-    try {
-      return await renderKitty(buffer, {width, height, preserveAspectRatio});
-    } catch {
-      return render(buffer, {height, width, preserveAspectRatio});
-    }
-  }
+	// Check for terminal graphics support
+	// Note: We disable graphics protocols for GIF frames as they don't work well with log-update
+	if (!isGifFrame && supportsTerminalGraphics()) {
+		// Use terminal graphics protocol for high-quality rendering
+		try {
+			return await renderKitty(buffer, {width, height, preserveAspectRatio});
+		} catch {
+			return render(buffer, {height, width, preserveAspectRatio});
+		}
+	}
 
 	// Fall back to iTerm2 or ANSI blocks
 	return termImg(buffer, {

--- a/index.js
+++ b/index.js
@@ -70,6 +70,25 @@ function calculateWidthHeight(imageWidth, imageHeight, inputWidth, inputHeight, 
 	return {width, height};
 }
 
+// Heuristic check for Kitty graphics protocol support based on TTY + environment
+function isKittyGraphicsLikely() {
+	// Don't attempt native kitty rendering if stdout isn't a TTY
+	if (!process.stdout.isTTY) {
+		return false;
+	}
+
+	const env = process.env;
+
+	// Strong indicators
+	if (env.KITTY_WINDOW_ID) return true;
+	const term = env.TERM || '';
+	if (/kitty/i.test(term)) return true;
+	if (env.TERM_PROGRAM && env.TERM_PROGRAM.toLowerCase() === 'kitty') return true;
+
+	// Otherwise assume not
+	return false;
+}
+
 async function render(buffer, {width: inputWidth, height: inputHeight, preserveAspectRatio}) {
 	const image = await Jimp.fromBuffer(Buffer.from(buffer)); // eslint-disable-line n/prefer-global/buffer
 	const {bitmap} = image;
@@ -222,9 +241,10 @@ terminalImage.buffer = async (buffer, {width = '100%', height = '100%', preserve
 	if (!isGifFrame && process.stdout.isTTY && process.env.TERM_PROGRAM !== 'iTerm.app') {
 		const {env} = process;
 
-		// Check for environment variables that indicate Kitty or Kitty-like terminals
-		const isKittyLike = env.TERM === 'xterm-kitty'
-			|| env.KITTY_WINDOW_ID
+		// Use extracted helper for the primary Kitty/TTY heuristic.
+		// Keep a few historical fallbacks (WezTerm/konsole) that were previously checked inline.
+		const isKittyLike = isKittyGraphicsLikely()
+			|| env.TERM === 'xterm-kitty'
 			|| env.TERM_PROGRAM === 'WezTerm'
 			|| env.TERM_PROGRAM === 'konsole'
 			|| env.KONSOLE_VERSION;

--- a/index.js
+++ b/index.js
@@ -70,22 +70,37 @@ function calculateWidthHeight(imageWidth, imageHeight, inputWidth, inputHeight, 
 	return {width, height};
 }
 
-// Heuristic check for Kitty graphics protocol support based on TTY + environment
-function isKittyGraphicsLikely() {
-	// Don't attempt native kitty rendering if stdout isn't a TTY
+// Check if the terminal supports graphics protocols (Kitty, iTerm2 inline images, etc.)
+function supportsTerminalGraphics() {
+	// Don't attempt native graphics rendering if stdout isn't a TTY
 	if (!process.stdout.isTTY) {
 		return false;
 	}
 
 	const env = process.env;
 
-	// Strong indicators
+	// Strong indicators for Kitty
 	if (env.KITTY_WINDOW_ID) return true;
-	const term = env.TERM || '';
-	if (/kitty/i.test(term)) return true;
-	if (env.TERM_PROGRAM && env.TERM_PROGRAM.toLowerCase() === 'kitty') return true;
 
-	// Otherwise assume not
+	// Check TERM_PROGRAM for known graphics-capable terminals
+	const termProgram = env.TERM_PROGRAM || '';
+	const lowerTermProgram = termProgram.toLowerCase();
+	if (['kitty', 'wezterm', 'iterm.app', 'konsole', 'ghostty'].includes(lowerTermProgram)) {
+		return true;
+	}
+
+	// Check TERM for known patterns
+	const term = env.TERM || '';
+	if (/kitty/i.test(term) || term === 'xterm-ghostty') {
+		return true;
+	}
+
+	// Check for Konsole version (additional indicator)
+	if (env.KONSOLE_VERSION) {
+		return true;
+	}
+
+	// Otherwise assume not supported
 	return false;
 }
 
@@ -235,29 +250,16 @@ terminalImage.buffer = async (buffer, {width = '100%', height = '100%', preserve
 		return render(buffer, {height, width, preserveAspectRatio});
 	}
 
-	// Check for Kitty protocol support only if we're in an interactive terminal
-	// and not in iTerm2 (which has its own protocol)
-	// Note: We disable Kitty protocol for GIF frames as it doesn't work well with log-update
-	if (!isGifFrame && process.stdout.isTTY && process.env.TERM_PROGRAM !== 'iTerm.app') {
-		const {env} = process;
-
-		// Use extracted helper for the primary Kitty/TTY heuristic.
-		// Keep a few historical fallbacks (WezTerm/konsole) that were previously checked inline.
-		const isKittyLike = isKittyGraphicsLikely()
-			|| env.TERM === 'xterm-kitty'
-			|| env.TERM_PROGRAM === 'WezTerm'
-			|| env.TERM_PROGRAM === 'konsole'
-			|| env.KONSOLE_VERSION;
-
-		if (isKittyLike) {
-			// Use Kitty Graphics Protocol for high-quality rendering
-			try {
-				return await renderKitty(buffer, {width, height, preserveAspectRatio});
-			} catch {
-				return render(buffer, {height, width, preserveAspectRatio});
-			}
-		}
-	}
+  // Check for terminal graphics support
+  // Note: We disable graphics protocols for GIF frames as they don't work well with log-update
+  if (!isGifFrame && supportsTerminalGraphics()) {
+    // Use terminal graphics protocol for high-quality rendering
+    try {
+      return await renderKitty(buffer, {width, height, preserveAspectRatio});
+    } catch {
+      return render(buffer, {height, width, preserveAspectRatio});
+    }
+  }
 
 	// Fall back to iTerm2 or ANSI blocks
 	return termImg(buffer, {


### PR DESCRIPTION
I had this library in some old code, and I noticed that it wasn't working as expected with [Ghostty](https://ghostty.org/). 

This patch refactors the terminal graphics capability detection to hopefully make it a bit less terminal-specific. I've only tried it with **Terminal.app**, **kitty**, and **Ghostty** and that works now at least.

### Before
**Ghostty**:
<img width="912" height="740" alt="Screenshot 2025-12-11 at 12 53 29" src="https://github.com/user-attachments/assets/d8d267f0-26f8-49f8-b569-273ca025f068" />

### After
**Ghostty** vs. macOS **Terminal.app**:
<img width="1294" height="636" alt="Screenshot 2025-12-11 at 12 48 48" src="https://github.com/user-attachments/assets/24e2d225-aab1-4f97-a21c-722836956e03" />

**KiTTY** still works:
<img width="797" height="640" alt="Screenshot 2025-12-11 at 12 50 53" src="https://github.com/user-attachments/assets/9c1d1d01-9d5a-4124-ac78-d6a739725e4a" />
